### PR TITLE
Support xenial using Snap package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ script:
   - inspec --version
   - ansible-playbook -i test/inventory test/test.yml --syntax-check
   - ansible-playbook -i test/inventory test/test.yml --connection=local -vvv
-  - inspec exec test/integration/default/test_spec.rb
+  - inspec exec test/integration/default/test_spec.rb --chef-license=accept-silent --log-level=debug
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ dist: "xenial"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt
-  - wget https://packages.chef.io/files/stable/inspec/4.3.2/ubuntu/18.04/inspec_4.3.2-1_amd64.deb
 
 install:
   - pip install ansible==2.8
-  - sudo dpkg -i inspec_4.3.2-1_amd64.deb
 
 script:
   - sudo lsb_release -a
   - ansible --version
-  - inspec --version
   - ansible-playbook -i test/inventory test/test.yml --syntax-check
   - ansible-playbook -i test/inventory test/test.yml --connection=local -vvv
   - snap services amazon-ssm-agent

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ script:
   - inspec --version
   - ansible-playbook -i test/inventory test/test.yml --syntax-check
   - ansible-playbook -i test/inventory test/test.yml --connection=local -vvv
-  - inspec exec test/integration/default/test_spec.rb --chef-license=accept-silent --log-level=debug
-  
+  - snap services amazon-ssm-agent

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,21 @@
 language: python
 python: "2.7"
 sudo: "required"
-dist: "trusty"
+dist: "xenial"
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt
+  - wget https://packages.chef.io/files/stable/inspec/4.3.2/ubuntu/18.04/inspec_4.3.2-1_amd64.deb
 
 install:
-  - pip install ansible==2.4
-  - gem install inspec
+  - pip install ansible==2.8
+  - dpkg -i inspec_4.3.2-1_amd64.deb
 
 script:
   - sudo lsb_release -a
-  - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
-  - ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -vvv
-  - sleep 15
+  - ansible --version
+  - inspec --version
+  - ansible-playbook -i test/inventory test/test.yml --syntax-check
+  - ansible-playbook -i test/inventory test/test.yml --connection=local -vvv
   - inspec exec test/integration/default/test_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - pip install ansible==2.8
-  - dpkg -i inspec_4.3.2-1_amd64.deb
+  - sudo dpkg -i inspec_4.3.2-1_amd64.deb
 
 script:
   - sudo lsb_release -a

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   description: Installs aws-ssm-agent
   company: Traveloka
-  min_ansible_version: 2.1
+  min_ansible_version: 2.8
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,11 +22,14 @@
 
     - block: # install only when Ubuntu version >= 16.04
 
-        - name: install aws ssm-agent with snap
+        - name: install amazon-ssm-agent with snap
           snap:
             name: "amazon-ssm-agent"
             classic: "yes"
             state: "present"
+
+        - name: ensure amazon-ssm-agent is started and enabled on boot
+          command: "snap start --enable amazon-ssm-agent"
 
       when: ansible_distribution_version is version_compare('16.04', '>=')
       

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,34 @@
 # tasks file for aws-ssm-agent
 
 - block:
-    - name: install aws ssm-agent
-      apt:
-        deb: "{{ aws_ssm_agent_url }}"
-        state: present
-        update_cache: yes
-        cache_valid_time: "{{ apt_cache_valid_time | default(omit) }}"
 
-    - name: ensure ssm-agent service running and enabled on boot
-      service:
-        name: "{{ aws_ssm_agent_service_name }}"
-        enabled: yes
-        state: started
+    - block: # install only when Ubuntu version > 16.04
 
+        - name: install aws ssm-agent with deb package
+          apt:
+            deb: "{{ aws_ssm_agent_url }}"
+            state: present
+            update_cache: yes
+            cache_valid_time: "{{ apt_cache_valid_time | default(omit) }}"
+
+        - name: ensure ssm-agent service running and enabled on boot
+          service:
+            name: "{{ aws_ssm_agent_service_name }}"
+            enabled: yes
+            state: started
+      
+      when: ansible_distribution_version is version_compare('16.04', '<')
+
+    - block: # install only when Ubuntu version >= 16.04
+
+        - name: install aws ssm-agent with snap
+          snap:
+            name: "amazon-ssm-agent"
+            classic: "yes"
+            state: "present"
+
+      when: ansible_distribution_version is version_compare('16.04', '>=')
+      
   become: yes
   become_method: sudo
   tags:


### PR DESCRIPTION
Starting from 20180627 release of Xenial, aws-ssm agent is pre-installed using Snap.
https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html#agent-install-ubuntu-snap

This change enable this role to install using Snap on Xenial distribution or later, and keep using Debian package installer for Precise or earlier. This role will not support installation using Debian for Xenial distribution or later.