### PR TITLE
Change snap service check to use systemd

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,10 @@
             channel: "candidate"
 
         - name: ensure amazon-ssm-agent is started and enabled on boot
-          command: "snap start --enable amazon-ssm-agent"
+          systemd:
+            name: "{{ aws_ssm_agent_systemd_name }}"
+            enabled: yes
+            state: started
 
       when: ansible_distribution_version is version_compare('16.04', '>=')
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 
 aws_ssm_agent_service_name: amazon-ssm-agent
+aws_ssm_agent_systemd_name: snap.amazon-ssm-agent.amazon-ssm-agent.service


### PR DESCRIPTION
Change service check for ubuntu >= 16.04 that use snap installation to use systemd instead of `snap` command.